### PR TITLE
Remove tailing comma in authors name in the search for a book activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.coo_bookshelf"
-        minSdk 34
+        minSdk 35
         targetSdk 36
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/example/coo_bookshelf/services/model/DocumentsResponse.java
+++ b/app/src/main/java/com/example/coo_bookshelf/services/model/DocumentsResponse.java
@@ -82,6 +82,14 @@ public class DocumentsResponse {
       sb.append(name).append(", ");
     }
 
+    // If ta coma is the last character in the string remove it.
+      if(sb.charAt(sb.length() - 2) == ','){
+      var startIndex = sb.length() - 2;
+      var endIndex = sb.length();
+
+       sb.delete(startIndex, endIndex);
+    }
+
     return sb.toString();
   }
 


### PR DESCRIPTION
- Bumped min SDK version to 35 to stop the compiler warning when using get().

- Fixed trailing comma issue. #38 